### PR TITLE
Fix Day of week axis label

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -942,7 +942,7 @@ def route_history():
         fig, ax = fig_start()
         ax.hist(day_of_week, bins=7, range=(-0.5, 6.5), orientation='horizontal')
         ax.set_xlabel(_('Tracks played'))
-        ax.set_ylabel(_('Time of day'))
+        ax.set_ylabel(_('Day of week'))
         plt.yticks((0, 1, 2, 3, 4, 5, 6), (_('Monday'), _('Tuesday'), _('Wednesday'), _('Thursday'), _('Friday'), _('Saturday'), _('Sunday')))
         summary_day_of_week = fig_end(fig)
 


### PR DESCRIPTION
<img width="620" alt="image" src="https://user-images.githubusercontent.com/26070412/224809407-b5827c85-5285-4faa-92df-69abb7d78276.png">

The Y label here should state "Day of week", instead of "Time of day"